### PR TITLE
Fix typos in Ursun's Sacred Land Route

### DIFF
--- a/docs/kislev.md
+++ b/docs/kislev.md
@@ -32,8 +32,8 @@
     * Control provinces:
         * The Blasted Wastes, The Haunted Forest, The Howling Wastes, The Plain of Zharr, The Wolf Lands and Zorn Uzkul
 * **Route II - Ursun's Sacred Land**
-        * Black Blood Pass, Dukhlys Forest, Eastern Oblast, Northern Oblast, River Lynsk, River Urskoy, The Cursed City 
-        and Troll Country
+    * Control provinces:
+        * Black Blood Pass, Dukhlys Forest, Eastern Oblast, Northern Oblast, River Lynsk, River Urskoy, The Cursed City and Troll Country
 * **Route III - Unbearable In-law**
     * Destroy factions:
         * Legion of Chaos


### PR DESCRIPTION
Adds a control province bullet point in line with all others, ensures provinces bullet point works, moves Troll Country to the same line as the rest